### PR TITLE
Enhance report with product metadata, market Sankey, and impact comparison (Issue-68)

### DIFF
--- a/src/materia_epd/pipeline/report.py
+++ b/src/materia_epd/pipeline/report.py
@@ -3,6 +3,8 @@ import json
 import pandas as pd
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
+from matplotlib.patches import PathPatch, FancyBboxPatch
+from matplotlib.path import Path as MplPath
 import tempfile
 from reportlab.pdfgen import canvas
 from reportlab.lib.pagesizes import A4
@@ -11,10 +13,12 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 from pathlib import Path
 from materia_epd.epd.models import IlcdProcess
+from materia_epd.geo.locations import get_location_attribute, get_location_color
 
 
 def build_report(
     report_uuid: str,
+    process: IlcdProcess,
     epd_entries: List[IlcdProcess],
     avg_impacts: Dict[str, Dict[str, Any]],
     avg_physical: Dict[str, Any],
@@ -30,6 +34,20 @@ def build_report(
     """
     rejected_epds = rejected_epds or []
 
+    process_name = (
+        process.matches.get("name")
+        or process.matches.get("product_name")
+        or process.matches.get("product")
+        or "Unknown product"
+    )
+    categories = (
+        process.matches.get("categories")
+        or process.matches.get("product_categories")
+        or []
+    )
+    process.get_lcia_results()
+    previous_impacts = {x["name"]: x["values"] for x in process.lcia_results}
+
     report: Dict[str, Any] = {
         "meta": {
             "report_uuid": report_uuid,
@@ -38,14 +56,23 @@ def build_report(
                 "initial_epds": initial_epds,
                 "selected_epds": selected_epds,
                 "rejected_count": len(rejected_epds),
+                "recipe_type": process.matches.get("type"),
             },
             "indicators": list(avg_impacts.keys()),
+            "product": {
+                "name": process_name,
+                "categories": categories,
+                "hs_code": process.hs_class,
+                "target_location": process.loc,
+            },
+            "market": process.market,
         },
         "epds": [],
         "average": {
             "physical": avg_physical,
             "impacts": avg_impacts,
         },
+        "previous": {"impacts": previous_impacts},
         "rejected": [
             {"epd_uuid": uuid, "reasons": reasons} for (uuid, reasons) in rejected_epds
         ],
@@ -61,6 +88,140 @@ def build_report(
         )
 
     return report
+
+
+def _direction(prev_value: float, new_value: float, tolerance: float = 1e-12) -> str:
+    delta = new_value - prev_value
+    if abs(delta) <= tolerance:
+        return "no-change"
+    return "increase" if delta > 0 else "decrease"
+
+
+def _build_impact_comparison_table(report: Dict[str, Any]) -> pd.DataFrame:
+    previous = report.get("previous", {}).get("impacts", {})
+    current = report.get("average", {}).get("impacts", {})
+
+    rows = []
+    for indicator, curr_values in current.items():
+        prev_values = previous.get(indicator, {})
+        for module in sorted(set(prev_values) | set(curr_values)):
+            prev_value = float(prev_values.get(module, 0.0))
+            curr_value = float(curr_values.get(module, 0.0))
+            rows.append(
+                {
+                    "Indicator": indicator,
+                    "Module": module,
+                    "Previous": prev_value,
+                    "Current": curr_value,
+                    "Delta": curr_value - prev_value,
+                    "Direction": _direction(prev_value, curr_value),
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _draw_market_structure_sankey(report: Dict[str, Any], output_png: str):
+    market = report.get("meta", {}).get("market", {})
+    if not market:
+        return None
+
+    items = sorted(market.items(), key=lambda kv: kv[1], reverse=True)
+    fig, ax = plt.subplots(figsize=(11, 6), dpi=240)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.axis("off")
+    fig.patch.set_facecolor("white")
+    ax.set_facecolor("white")
+
+    left_x, right_x = 0.16, 0.82
+    node_w = 0.026
+
+    values = [v for _, v in items]
+    top, bottom = 0.90, 0.10
+    gap = 0.020
+    avail = top - bottom - gap * (len(values) - 1)
+    scale = avail / sum(values)
+    heights = [v * scale for v in values]
+
+    tops = []
+    y = top
+    for h in heights:
+        tops.append(y)
+        y -= h + gap
+
+    sink_total = sum(heights)
+    sink_top = 0.5 + sink_total / 2
+    cursor = sink_top
+
+    def ribbon(x0, x1, y0t, y0b, y1t, y1b, color):
+        c1 = x0 + 0.37 * (x1 - x0)
+        c2 = x1 - 0.37 * (x1 - x0)
+        verts = [
+            (x0, y0t),
+            (c1, y0t),
+            (c2, y1t),
+            (x1, y1t),
+            (x1, y1b),
+            (c2, y1b),
+            (c1, y0b),
+            (x0, y0b),
+            (x0, y0t),
+        ]
+        codes = [1, 4, 4, 4, 2, 4, 4, 4, 79]
+        ax.add_patch(PathPatch(MplPath(verts, codes), facecolor=color, edgecolor="none"))
+
+    def rounded_box(x, y, w, h, fc):
+        ax.add_patch(
+            FancyBboxPatch(
+                (x, y),
+                w,
+                h,
+                boxstyle="round,pad=0,rounding_size=0.004",
+                facecolor=fc,
+                edgecolor="none",
+            )
+        )
+
+    for (loc, _), h, t in zip(items, heights, tops):
+        b = t - h
+        t2 = cursor
+        b2 = t2 - h
+        cursor = b2
+        color = get_location_color(loc).get("rgba") or [0.5, 0.5, 0.5, 0.25]
+        ribbon(left_x + node_w, right_x, t, b, t2, b2, color)
+
+    for (loc, share), h, t in zip(items, heights, tops):
+        loc_hex = get_location_color(loc).get("hex") or "#6B7280"
+        rounded_box(left_x, t - h, node_w, h, loc_hex)
+        yc = t - h / 2
+        name = get_location_attribute(loc, "Name") or loc
+        ax.text(
+            left_x - 0.02,
+            yc,
+            f"{name}  {share:.1%}",
+            ha="right",
+            va="center",
+            fontsize=10.5,
+            color="#222222",
+        )
+
+    import_country = report.get("meta", {}).get("product", {}).get("name", "Product")
+    target_loc = report.get("meta", {}).get("product", {}).get("target_location")
+    target_name = get_location_attribute(target_loc, "Name") or "Target market"
+    target_hex = get_location_color(target_loc).get("hex") or "#00A1DE"
+    rounded_box(right_x, 0.5 - sink_total / 2, node_w, sink_total, target_hex)
+    ax.text(
+        right_x + 0.03,
+        0.5,
+        f"{target_name} market ({import_country})",
+        va="center",
+        fontsize=12.5,
+        color="#1f2937",
+    )
+
+    plt.savefig(output_png, bbox_inches="tight", dpi=240, facecolor="white")
+    plt.close(fig)
+    return output_png
 
 
 def draw_report(report: Dict[str, Any], out_path: Path, report_uuid: str):
@@ -210,12 +371,53 @@ def draw_report(report: Dict[str, Any], out_path: Path, report_uuid: str):
     # Page 1
     c.setFont("Helvetica-Bold", 16)
     c.drawString(40, page_h - 40, "EPD Averaging Summary")
+    c.setFont("Helvetica", 11)
+    product_meta = report.get("meta", {}).get("product", {})
+    categories = ", ".join(product_meta.get("categories") or []) or "n/a"
+    c.drawString(40, page_h - 62, f"Product: {product_meta.get('name', 'Unknown')}")
+    c.drawString(40, page_h - 78, f"HS code: {product_meta.get('hs_code', 'n/a')}")
+    c.drawString(40, page_h - 94, f"Categories: {categories}")
+
     reader = ImageReader(stacked_img)
-    x, y, w, h = fit_image(reader, page_w, page_h, margin=40, y_offset=-10)
+    x, y, w, h = fit_image(reader, page_w, page_h, margin=40, y_offset=-50)
     c.drawImage(
         stacked_img, x, y, width=w, height=h, preserveAspectRatio=True, mask="auto"
     )
     c.showPage()
+
+    # ---------------------- Input EPD overview page ----------------------
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(40, page_h - 40, "Overview of Input EPDs")
+    c.setFont("Helvetica", 10)
+    y = page_h - 72
+    c.drawString(40, y, "EPD UUID")
+    c.drawString(340, y, "Mass [kg]")
+    c.drawString(430, y, "Volume [m³]")
+    y -= 12
+    c.line(40, y, page_w - 40, y)
+    y -= 14
+    for epd in report["epds"][:28]:
+        c.drawString(40, y, str(epd["epd_uuid"])[:48])
+        mass = epd["physical"].get("mass")
+        volume = epd["physical"].get("volume")
+        c.drawRightString(400, y, "-" if mass is None else f"{mass:.4g}")
+        c.drawRightString(500, y, "-" if volume is None else f"{volume:.4g}")
+        y -= 16
+        if y < 60:
+            break
+    c.showPage()
+
+    # ---------------------- Market structure (Sankey) ----------------------
+    sankey_img = tempfile.mktemp(".png")
+    if _draw_market_structure_sankey(report, sankey_img):
+        c.setFont("Helvetica-Bold", 16)
+        c.drawString(40, page_h - 40, "Market Structure (Sankey)")
+        reader_market = ImageReader(sankey_img)
+        x, y, w, h = fit_image(reader_market, page_w, page_h, margin=40)
+        c.drawImage(
+            sankey_img, x, y, width=w, height=h, preserveAspectRatio=True, mask="auto"
+        )
+        c.showPage()
 
     # ---------------------- Physical data page ----------------------
     fig, axes = plt.subplots(3, 4, figsize=(10, 8))
@@ -357,6 +559,45 @@ def draw_report(report: Dict[str, Any], out_path: Path, report_uuid: str):
         combined_img, x, y, width=w, height=h, preserveAspectRatio=True, mask="auto"
     )
     c.showPage()
+
+    # ---------------------- Method + tabular comparison page ----------------------
+    c.setFont("Helvetica-Bold", 16)
+    c.drawString(40, page_h - 40, "Averaging Method and Results Table")
+    recipe_type = report.get("meta", {}).get("pipeline", {}).get("recipe_type")
+    if recipe_type == "market-average":
+        method = (
+            "Method: market-weighted averaging. Country-level averages are combined "
+            "using market share weights for the product HS code."
+        )
+    else:
+        method = (
+            "Method: arithmetic averaging. Matching EPDs are averaged with equal "
+            "weight for each indicator and module."
+        )
+    c.setFont("Helvetica", 10)
+    method_text = c.beginText(40, page_h - 62)
+    for line in method.split(". "):
+        method_text.textLine(line.strip() + ("." if not line.endswith(".") else ""))
+    c.drawText(method_text)
+
+    table_df = _build_impact_comparison_table(report).head(20)
+    y = page_h - 120
+    headers = ["Indicator", "Module", "Previous", "Current", "Direction"]
+    x_cols = [40, 230, 290, 360, 445]
+    for xh, hname in zip(x_cols, headers):
+        c.drawString(xh, y, hname)
+    y -= 8
+    c.line(40, y, page_w - 40, y)
+    y -= 14
+    for _, row in table_df.iterrows():
+        c.drawString(40, y, str(row["Indicator"])[:33])
+        c.drawString(230, y, str(row["Module"]))
+        c.drawRightString(342, y, f"{row['Previous']:.3g}")
+        c.drawRightString(420, y, f"{row['Current']:.3g}")
+        c.drawString(445, y, str(row["Direction"]))
+        y -= 14
+        if y < 50:
+            break
 
     c.save()
 

--- a/src/materia_epd/pipeline/stages.py
+++ b/src/materia_epd/pipeline/stages.py
@@ -227,6 +227,7 @@ class BuildReportStage:
     def run(self, ctx: EpdPipelineContext) -> None:
         ctx.report = build_report(
             report_uuid=ctx.process.uuid,
+            process=ctx.process,
             epd_entries=ctx.filtered_epds,
             avg_impacts=ctx.avg_gwps,
             avg_physical=ctx.avg_properties,


### PR DESCRIPTION
### Motivation
- Extend the pipeline report so it can surface product metadata (name, categories, HS), an overview of input EPDs, a Sankey of market structure, an explanation of the averaging method, and a table comparing previous vs current impact values and direction of change as described in Issue-68.
- Use existing location files (color metadata) and computed market shares for the HS code to visualise market composition in the report.

### Description
- Updated `build_report` to accept the `process` (`IlcdProcess`) and include product metadata, `recipe_type`, `market` shares and `previous` impact values extracted from the reference process by calling `process.get_lcia_results()`; the report JSON payload now contains `meta.product`, `meta.market`, and `previous.impacts`.
- Added helper functions: `_direction` (determine increase/decrease/no-change), `_build_impact_comparison_table` (produce per-indicator/module comparison rows), and `_draw_market_structure_sankey` (render Sankey using `ColorHex`/`ColorRGBA` from location data) in `src/materia_epd/pipeline/report.py` and imported `get_location_attribute`/`get_location_color`.
- Extended `draw_report` to embed in the PDF: product and categories on the summary page, an "Overview of Input EPDs" page, a "Market Structure (Sankey)" page, and an "Averaging Method and Results Table" page that prints a method description and a tabular previous-vs-current comparison including direction of change.
- Wire-up change in pipeline: `BuildReportStage` now passes `process=ctx.process` into `build_report` so process metadata is available during report construction.

### Testing
- Ran `python -m py_compile src/materia_epd/pipeline/report.py src/materia_epd/pipeline/stages.py` and it succeeded (syntax checked).
- Attempted `pytest` runs targeted at `tests/unit/test_pipeline.py`, `tests/unit/test_models.py`, and `tests/unit/test_resources.py` but execution in this environment failed: one run failed due to repository `addopts` containing coverage plugin args (pytest reported unrecognized arguments), and another run failed because `numpy` is not available in the execution environment; these are environmental issues unrelated to the implemented code changes.
- Committed the changes with message: `Enhance pipeline report with market Sankey and comparison sections`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22286b850832fa2981bde05442541)