### PR TITLE
Handle singular matrix in physics projection solver

### DIFF
--- a/src/materia_epd/core/physics.py
+++ b/src/materia_epd/core/physics.py
@@ -171,7 +171,10 @@ def _project_logs_onto_eq(
 
     rhs = np.concatenate([2.0 * W @ base_logs, b_eq, d])
 
-    x = np.linalg.solve(K, rhs)
+    try:
+        x = np.linalg.solve(K, rhs)
+    except np.linalg.LinAlgError:
+        x, *_ = np.linalg.lstsq(K, rhs, rcond=None)
     return x[:n]
 
 


### PR DESCRIPTION
### Motivation
- Prevent `numpy.linalg.LinAlgError: Singular matrix` raised by `_project_logs_onto_eq` during material rescale/projection when the KKT system is singular due to dependent constraints.

### Description
- Wrap the direct solve in `_project_logs_onto_eq` with a `try/except` that uses `np.linalg.solve(K, rhs)` as the fast path and falls back to `np.linalg.lstsq(K, rhs, rcond=None)` when `np.linalg.LinAlgError` is raised, returning the same `x[:n]` slice; change applied in `src/materia_epd/core/physics.py`.

### Testing
- Ran `pytest -q` but it failed in this container due to the project `addopts` requiring the `pytest-cov` plugin which is not installed locally; tests were not executed.  
- Ran `pytest -q -o addopts='' tests/unit/test_physics.py` to target the physics tests but the run failed because `numpy` is not installed in the current environment, so the test execution could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7237f8d7c832f8122f1dd4c974d2c)