### PR TITLE
Derive A4 transport impacts from market shares and add per-kg transport factors

### DIFF
--- a/src/materia_epd/data/locations/Australia and New Zealand.json
+++ b/src/materia_epd/data/locations/Australia and New Zealand.json
@@ -17,5 +17,13 @@
     0.86,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.3731,
+      "Climate change-Fossil": 0.3731,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Caribbean.json
+++ b/src/materia_epd/data/locations/Caribbean.json
@@ -39,5 +39,13 @@
     0.86,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.1644,
+      "Climate change-Fossil": 0.1644,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Central America.json
+++ b/src/materia_epd/data/locations/Central America.json
@@ -19,5 +19,13 @@
     0.39,
     0.46,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.2456,
+      "Climate change-Fossil": 0.2456,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Central Asia.json
+++ b/src/materia_epd/data/locations/Central Asia.json
@@ -16,5 +16,13 @@
     0.54,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.1863,
+      "Climate change-Fossil": 0.1863,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Eastern Africa.json
+++ b/src/materia_epd/data/locations/Eastern Africa.json
@@ -33,5 +33,13 @@
     0.39,
     0.86,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.2536,
+      "Climate change-Fossil": 0.2536,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Eastern Asia.json
+++ b/src/materia_epd/data/locations/Eastern Asia.json
@@ -19,5 +19,13 @@
     0.86,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.3657,
+      "Climate change-Fossil": 0.3657,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Eastern Europe.json
+++ b/src/materia_epd/data/locations/Eastern Europe.json
@@ -21,5 +21,13 @@
     0.81,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.0582,
+      "Climate change-Fossil": 0.0582,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/LUX.json
+++ b/src/materia_epd/data/locations/LUX.json
@@ -11,5 +11,13 @@
     0.63,
     0.87,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.0209,
+      "Climate change-Fossil": 0.0209,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Melanesia.json
+++ b/src/materia_epd/data/locations/Melanesia.json
@@ -16,5 +16,13 @@
     0.43,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.3917,
+      "Climate change-Fossil": 0.3917,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Micronesia.json
+++ b/src/materia_epd/data/locations/Micronesia.json
@@ -19,5 +19,13 @@
     0.86,
     0.44,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.4228,
+      "Climate change-Fossil": 0.4228,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Middle Africa.json
+++ b/src/materia_epd/data/locations/Middle Africa.json
@@ -20,5 +20,13 @@
     0.86,
     0.67,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.1551,
+      "Climate change-Fossil": 0.1551,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Northern Africa.json
+++ b/src/materia_epd/data/locations/Northern Africa.json
@@ -18,5 +18,13 @@
     0.86,
     0.51,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.0865,
+      "Climate change-Fossil": 0.0865,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Northern America.json
+++ b/src/materia_epd/data/locations/Northern America.json
@@ -16,5 +16,13 @@
     0.6,
     0.86,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.2003,
+      "Climate change-Fossil": 0.2003,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Northern Europe.json
+++ b/src/materia_epd/data/locations/Northern Europe.json
@@ -27,5 +27,13 @@
     0.39,
     0.76,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.0636,
+      "Climate change-Fossil": 0.0636,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Polynesia.json
+++ b/src/materia_epd/data/locations/Polynesia.json
@@ -21,5 +21,13 @@
     0.86,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.4148,
+      "Climate change-Fossil": 0.4148,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/South America.json
+++ b/src/materia_epd/data/locations/South America.json
@@ -27,5 +27,13 @@
     0.39,
     0.86,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.221,
+      "Climate change-Fossil": 0.221,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/South-eastern Asia.json
+++ b/src/materia_epd/data/locations/South-eastern Asia.json
@@ -22,5 +22,13 @@
     0.85,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.3015,
+      "Climate change-Fossil": 0.3015,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Southern Africa.json
+++ b/src/materia_epd/data/locations/Southern Africa.json
@@ -16,5 +16,13 @@
     0.39,
     0.86,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.2249,
+      "Climate change-Fossil": 0.2249,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Southern Asia.json
+++ b/src/materia_epd/data/locations/Southern Asia.json
@@ -20,5 +20,13 @@
     0.86,
     0.52,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.2497,
+      "Climate change-Fossil": 0.2497,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Southern Europe.json
+++ b/src/materia_epd/data/locations/Southern Europe.json
@@ -27,5 +27,13 @@
     0.6,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.0722,
+      "Climate change-Fossil": 0.0722,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Western Africa.json
+++ b/src/materia_epd/data/locations/Western Africa.json
@@ -28,5 +28,13 @@
     0.67,
     0.39,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.1216,
+      "Climate change-Fossil": 0.1216,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Western Asia.json
+++ b/src/materia_epd/data/locations/Western Asia.json
@@ -29,5 +29,13 @@
     0.39,
     0.86,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.1654,
+      "Climate change-Fossil": 0.1654,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/data/locations/Western Europe.json
+++ b/src/materia_epd/data/locations/Western Europe.json
@@ -20,5 +20,13 @@
     0.39,
     0.86,
     0.2
-  ]
+  ],
+  "TransportImpactPerKgByTarget": {
+    "LUX": {
+      "Climate change-Total": 0.0434,
+      "Climate change-Fossil": 0.0434,
+      "Climate change-Biogenic": 0.0,
+      "Climate change-Land use and land use change": 0.0
+    }
+  }
 }

--- a/src/materia_epd/geo/locations.py
+++ b/src/materia_epd/geo/locations.py
@@ -36,3 +36,37 @@ def get_location_color(location_code: str):
         "hex": location_data.get("ColorHex"),
         "rgba": location_data.get("ColorRGBA"),
     }
+
+
+def get_transport_impact_per_kg(
+    source_location_code: str, target_location_code: str | None = None
+) -> dict[str, float]:
+    """Return transport impacts [kg CO2e / kg product] for a source location."""
+    try:
+        source_data = get_location_data(source_location_code) or {}
+    except Exception:
+        return {}
+
+    impact = (
+        (source_data.get("TransportImpactPerKgByTarget") or {}).get(target_location_code)
+        if target_location_code
+        else None
+    ) or (source_data.get("TransportImpactPerKgByTarget") or {}).get("default")
+    if isinstance(impact, dict):
+        return impact
+
+    parent = source_data.get("Parent")
+    if not parent:
+        return {}
+
+    try:
+        parent_data = get_location_data(parent) or {}
+    except Exception:
+        return {}
+
+    impact = (
+        (parent_data.get("TransportImpactPerKgByTarget") or {}).get(target_location_code)
+        if target_location_code
+        else None
+    ) or (parent_data.get("TransportImpactPerKgByTarget") or {}).get("default")
+    return impact if isinstance(impact, dict) else {}

--- a/src/materia_epd/pipeline/recipes.py
+++ b/src/materia_epd/pipeline/recipes.py
@@ -9,6 +9,7 @@ from materia_epd.pipeline.stages import (
     ValidateMassConversionStage,
     ComputeAverageImpactsStage,
     ComputeMarketAverageImpactsStage,
+    DeriveTransportA4ImpactsStage,
     ValidateAveragedImpactsStage,
     BuildReportStage,
 )
@@ -36,6 +37,7 @@ class RecipeFactory:
                 ComputeAveragePropertiesStage(),
                 ValidateMassConversionStage(),
                 ComputeMarketAverageImpactsStage(),
+                DeriveTransportA4ImpactsStage(),
                 ValidateAveragedImpactsStage(),
                 BuildReportStage(),
             ]

--- a/src/materia_epd/pipeline/stages.py
+++ b/src/materia_epd/pipeline/stages.py
@@ -17,6 +17,8 @@ from materia_epd.metrics.averaging import (
     average_material_properties,
     market_weighted_impacts,
 )
+from materia_epd.geo.locations import get_transport_impact_per_kg
+from materia_epd.geo.locations import get_location_attribute
 
 
 class PipelineStage(Protocol):
@@ -258,6 +260,92 @@ class ComputeMarketAverageImpactsStage:
             matched_countries=len(ctx.market_impacts),
             unmatched_epds=len(ctx.unmatched_epds),
         )
+
+
+class DeriveTransportA4ImpactsStage:
+    name = "derive-transport-a4-impacts"
+
+    def run(self, ctx: EpdPipelineContext) -> None:
+        if ctx.avg_gwps is None:
+            return
+
+        mass = (ctx.avg_properties or {}).get("mass")
+        if not isinstance(mass, (int, float)):
+            ctx.add_diagnostic(
+                kind="warning",
+                message="Skipped A4 transport derivation because mass is unavailable.",
+                stage=self.name,
+                process_uuid=ctx.process.uuid,
+            )
+            return
+
+        target_location = ctx.process.loc
+        grouped_market = self._aggregate_market_by_transport_location(
+            ctx.process.market or {}, target_location
+        )
+        weighted_impacts_per_kg: dict[str, float] = {}
+        total_share = 0.0
+        missing_locations: list[str] = []
+        for source_location, share in grouped_market.items():
+            impacts_per_kg = get_transport_impact_per_kg(source_location, target_location)
+            if not impacts_per_kg:
+                missing_locations.append(source_location)
+                continue
+
+            total_share += share
+            for indicator, value in impacts_per_kg.items():
+                weighted_impacts_per_kg[indicator] = (
+                    weighted_impacts_per_kg.get(indicator, 0.0) + share * value
+                )
+
+        if total_share <= 0:
+            ctx.add_diagnostic(
+                kind="warning",
+                message="Skipped A4 transport derivation because no transport factors were available for market entries.",  # noqa: E501
+                stage=self.name,
+                process_uuid=ctx.process.uuid,
+                missing_locations=missing_locations,
+            )
+            return
+
+        for indicator, weighted_value in weighted_impacts_per_kg.items():
+            per_kg = weighted_value / total_share
+            a4_value = per_kg * mass
+            indicator_modules = ctx.avg_gwps.setdefault(indicator, {})
+            indicator_modules["A4"] = round(a4_value, 6)
+
+        ctx.add_diagnostic(
+            kind="info",
+            message="Derived A4 transport impacts from mass and market shares.",
+            stage=self.name,
+            process_uuid=ctx.process.uuid,
+            mass=mass,
+            target_location=target_location,
+            grouped_market=grouped_market,
+            missing_locations=missing_locations,
+        )
+
+    @staticmethod
+    def _aggregate_market_by_transport_location(
+        market: dict[str, float], target_location: str | None
+    ) -> dict[str, float]:
+        grouped_market: dict[str, float] = {}
+        for source_location, share in market.items():
+            if source_location == "RoW":
+                continue
+
+            if target_location and source_location == target_location:
+                grouped_key = target_location
+            else:
+                try:
+                    parent = get_location_attribute(source_location, "Parent")
+                except Exception:
+                    parent = None
+                grouped_key = parent or source_location
+
+            grouped_market[grouped_key] = grouped_market.get(grouped_key, 0.0) + share
+
+        return grouped_market
 
 
 class BuildReportStage:

--- a/tests/unit/test_locations.py
+++ b/tests/unit/test_locations.py
@@ -61,3 +61,24 @@ def test_get_location_color(monkeypatch):
         "hex": "#112233",
         "rgba": [0.07, 0.13, 0.2, 0.2],
     }
+
+
+def test_get_transport_impact_per_kg():
+    data = {
+        "LUX": {
+            "TransportImpactPerKgByTarget": {"LUX": {"Climate change-Total": 0.0209}},
+        },
+        "FRA": {"Parent": "Western Europe"},
+        "Western Europe": {
+            "TransportImpactPerKgByTarget": {
+                "LUX": {"Climate change-Total": 0.0434},
+            },
+        },
+    }
+    loc.get_location_data = lambda code: data[code]
+
+    local = loc.get_transport_impact_per_kg("LUX", "LUX")
+    assert local["Climate change-Total"] == 0.0209
+
+    from_parent = loc.get_transport_impact_per_kg("FRA", "LUX")
+    assert from_parent == {"Climate change-Total": 0.0434}

--- a/tests/unit/test_pipeline_transport.py
+++ b/tests/unit/test_pipeline_transport.py
@@ -1,0 +1,50 @@
+from types import SimpleNamespace
+
+from materia_epd.pipeline.context import EpdPipelineContext
+from materia_epd.pipeline.stages import DeriveTransportA4ImpactsStage
+import materia_epd.pipeline.stages as stages
+
+
+def test_derive_transport_a4_impacts_market_weighted(monkeypatch):
+    monkeypatch.setattr(
+        stages,
+        "get_location_attribute",
+        lambda code, attr: {
+            "DEU": "Western Europe",
+            "FRA": "Western Europe",
+            "CHN": "Eastern Asia",
+        }.get(code)
+        if attr == "Parent"
+        else None,
+    )
+    monkeypatch.setattr(
+        stages,
+        "get_transport_impact_per_kg",
+        lambda src, tgt: {
+            "Western Europe": {
+                "Climate change-Total": 0.0636,
+                "Climate change-Fossil": 0.0636,
+            },
+            "Eastern Asia": {
+                "Climate change-Total": 0.3657,
+                "Climate change-Fossil": 0.3657,
+            },
+            "LUX": {"Climate change-Total": 0.0209, "Climate change-Fossil": 0.0209},
+        }.get(src, {}),
+    )
+
+    ctx = EpdPipelineContext(
+        process=SimpleNamespace(
+            uuid="proc-1",
+            loc="LUX",
+            market={"DEU": 0.5, "FRA": 0.2, "CHN": 0.2, "RoW": 0.1},
+        ),
+        avg_properties={"mass": 2.0},
+        avg_gwps={"Climate change-Total": {"A1-A3": 1.0}},
+    )
+
+    DeriveTransportA4ImpactsStage().run(ctx)
+
+    # RoW ignored => shares rescaled on 0.9; weighted per-kg = (0.7*0.0636 + 0.2*0.3657) / 0.9
+    assert ctx.avg_gwps["Climate change-Total"]["A4"] == 0.261467
+    assert ctx.avg_gwps["Climate change-Fossil"]["A4"] == 0.261467


### PR DESCRIPTION
### Motivation
- Provide transport impact factors per kilogram for locations so A4 (transport) impacts can be derived when only mass and market shares are available.
- Allow market-average pipelines to automatically compute A4 impacts from source-target transport factors and product mass.

### Description
- Added `TransportImpactPerKgByTarget` entries to multiple location JSON files (including regional parents and `LUX`) to provide per-kg transport impact factors by target location.
- Implemented `get_transport_impact_per_kg` in `src/materia_epd/geo/locations.py` to read transport factors from a location or its parent and return a dict of indicator -> value.
- Added `DeriveTransportA4ImpactsStage` to `src/materia_epd/pipeline/stages.py` which aggregates market shares by transport source, fetches per-kg factors, computes weighted per-kg impacts, multiplies by product `mass`, and inserts rounded `A4` module values into `ctx.avg_gwps`.
- Integrated the new stage into the `market-average` recipe in `src/materia_epd/pipeline/recipes.py` and added helper `_aggregate_market_by_transport_location` logic.
- Added unit tests: `tests/unit/test_locations.py::test_get_transport_impact_per_kg` and new `tests/unit/test_pipeline_transport.py::test_derive_transport_a4_impacts_market_weighted` to validate lookup and A4 derivation behavior.

### Testing
- Ran unit tests covering the new code paths, including `test_get_transport_impact_per_kg` and `test_derive_transport_a4_impacts_market_weighted`, and they passed.
- Existing pipeline unit tests were exercised and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e726b6004c832f98bca95a886c5eb8)