### PR TITLE
Handle missing module impact values in impact comparison table

### DIFF
--- a/src/materia_epd/pipeline/report.py
+++ b/src/materia_epd/pipeline/report.py
@@ -100,6 +100,15 @@ def detect_declared_unit(avg_physical: dict) -> str | None:
     )
 
 
+def as_float(value: Any, default: float = 0.0) -> float:
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def build_impact_comparison_table(report: Dict[str, Any]) -> pd.DataFrame:
     prev, cur = report.get("previous", {}).get("impacts", {}), report.get(
         "average", {}
@@ -107,7 +116,8 @@ def build_impact_comparison_table(report: Dict[str, Any]) -> pd.DataFrame:
     rows = []
     for ind, cv in cur.items():
         for mod in sorted(set(prev.get(ind, {})) | set(cv)):
-            p, c = float(prev.get(ind, {}).get(mod, 0.0)), float(cv.get(mod, 0.0))
+            p = as_float(prev.get(ind, {}).get(mod), default=0.0)
+            c = as_float(cv.get(mod), default=0.0)
             rows.append(
                 {
                     "Indicator": ind,


### PR DESCRIPTION
### Motivation
- Prevent a `TypeError` when report data contains `None` (or missing) values for a module while building the impacts comparison table, so report generation doesn't crash.

### Description
- Add `as_float` helper and update `build_impact_comparison_table` to use `as_float` for previous and current module values, defaulting to `0.0` when values are `None` or non-numeric, preventing direct `float(None)` conversions and ensuring stable comparisons between `Previous` and `Current` values.

### Testing
- Ran `python -m compileall src/materia_epd/pipeline/report.py` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e72ddc40fc832f87b0ebda1524c07d)