### PR TITLE
Fix canvas variable shadowing in report drawing and add regression test

### DIFF
--- a/src/materia_epd/pipeline/report.py
+++ b/src/materia_epd/pipeline/report.py
@@ -633,12 +633,12 @@ def draw_report(report: Dict[str, Any], out_path: Path, report_uuid: str):
     for ax, ind in zip(axes, inds):
         cols = [f"{ind}_A1-A3", f"{ind}_A4", f"{ind}_C1234", f"{ind}_D"]
         vals = []
-        for c in cols:
-            series = impact_series(df, c)
-            avg_value = df_avg[c].iloc[0] if c in df_avg else 0.0
+        for col in cols:
+            series = impact_series(df, col)
+            avg_value = df_avg[col].iloc[0] if col in df_avg else 0.0
             # A4 can be derived at aggregate level and may not exist in source EPD rows.
             # In that case, show the derived aggregate value in the plot instead of a zero-only box.
-            if c.endswith("_A4") and (
+            if col.endswith("_A4") and (
                 len(series) == 0 or (series.abs() <= 1e-12).all()
             ) and abs(avg_value) > 1e-12:
                 series = pd.Series([avg_value])
@@ -649,7 +649,7 @@ def draw_report(report: Dict[str, Any], out_path: Path, report_uuid: str):
             ax.boxplot(box_vals, positions=box_pos, widths=0.6)
         ax.scatter(
             [1, 3, 5, 7],
-            [df_avg[c].iloc[0] if c in df_avg else 0.0 for c in cols],
+            [df_avg[col].iloc[0] if col in df_avg else 0.0 for col in cols],
             color="red",
             s=40,
             zorder=3,

--- a/tests/unit/test_report.py
+++ b/tests/unit/test_report.py
@@ -1,5 +1,24 @@
+from pathlib import Path
+
 from materia_epd.pipeline.report import build_impact_comparison_table
+from materia_epd.pipeline.report import draw_report
 from materia_epd.pipeline.report import flatten_impacts
+
+
+def _physical_template():
+    return {
+        "mass": 1.0,
+        "volume": None,
+        "surface": None,
+        "length": None,
+        "unit_count": None,
+        "gross_density": None,
+        "grammage": None,
+        "linear_density": None,
+        "layer_thickness": None,
+        "cross_sectional_area": None,
+        "weight_per_piece": None,
+    }
 
 
 def test_flatten_impacts_includes_a4_module():
@@ -33,3 +52,58 @@ def test_build_impact_comparison_table_adds_a4_when_missing():
     row = a4_rows.iloc[0]
     assert row["Previous"] == 0.0
     assert row["Current"] == 0.0
+
+
+def test_draw_report_does_not_shadow_canvas_with_indicator_columns(tmp_path: Path):
+    report = {
+        "epds": [
+            {
+                "epd_uuid": "epd-1",
+                "impacts": [
+                    {
+                        "name": "Climate change-Total",
+                        "values": {"A1-A3": 10.0, "C1": 1.0, "D": -0.5},
+                    },
+                    {
+                        "name": "Climate change-Fossil",
+                        "values": {"A1-A3": 5.0},
+                    },
+                    {
+                        "name": "Climate change-Biogenic",
+                        "values": {"A1-A3": 2.0},
+                    },
+                    {
+                        "name": "Climate change-Land use and land use change",
+                        "values": {"A1-A3": 1.0},
+                    },
+                ],
+                "physical": _physical_template(),
+            }
+        ],
+        "average": {
+            "impacts": {
+                "Climate change-Total": {"A1-A3": 10.0, "A4": 2.5, "C1": 1.0, "D": -0.5},
+                "Climate change-Fossil": {"A1-A3": 5.0},
+                "Climate change-Biogenic": {"A1-A3": 2.0},
+                "Climate change-Land use and land use change": {"A1-A3": 1.0},
+            },
+            "physical": _physical_template(),
+        },
+        "previous": {
+            "impacts": {
+                "Climate change-Total": {"A1-A3": 9.0, "A4": 2.0, "C1": 1.0, "D": -0.5}
+            }
+        },
+        "meta": {
+            "pipeline": {
+                "initial_epds": 1,
+                "selected_epds": 1,
+                "recipe_type": "market-average",
+            },
+            "product": {"name": "Test Product"},
+        },
+    }
+
+    draw_report(report, tmp_path, "shadowing-regression")
+
+    assert (tmp_path / "reports" / "shadowing-regression.pdf").exists()


### PR DESCRIPTION
### Motivation
- The PDF generation raised `AttributeError: 'str' object has no attribute 'setFont'` because a loop variable named `c` shadowed the ReportLab canvas object in `draw_report()`.

### Description
- Renamed the indicator-column loop variable from `c` to `col` in `src/materia_epd/pipeline/report.py` to avoid shadowing the canvas and updated the related list-comprehensions and condition checks accordingly.
- Updated the scatter value list comprehension to use `col` instead of the shadowed variable.
- Added a regression unit test `test_draw_report_does_not_shadow_canvas_with_indicator_columns` in `tests/unit/test_report.py` that exercises `draw_report()` with a minimal report payload and asserts the PDF output exists.
- Added a small `_physical_template()` helper in the test to provide required physical fields for the sample EPD.

### Testing
- `python -m compileall src/materia_epd/pipeline/report.py tests/unit/test_report.py` ran successfully (compilation OK).
- `pytest -q tests/unit/test_report.py` failed in this environment due to project `addopts` referencing coverage plugins not available here (pytest error about unrecognized arguments). 
- `PYTHONPATH=src pytest -q -o addopts='' tests/unit/test_report.py` failed due to missing runtime dependency `matplotlib` (`ModuleNotFoundError: No module named 'matplotlib'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e741dee930832f9f2199fd0a2b9fc7)